### PR TITLE
Workout with multiple repeats

### DIFF
--- a/src/main/scala/com.github.mgifos.workouts/model/Step.scala
+++ b/src/main/scala/com.github.mgifos.workouts/model/Step.scala
@@ -39,9 +39,9 @@ case class RepeatStep(count: Int, steps: Seq[Step]) extends Step {
 
   override def json(order: Int) = Json.obj(
     "stepId" -> JsNull,
-    "stepOrder" -> 2,
+    "stepOrder" -> order,
     "stepType" -> Json.obj(
-      "stepTypeId" -> 6,
+      "stepTypeId" -> typeId,
       "stepTypeKey" -> "repeat"),
     "numberOfIterations" -> count,
     "smartRepeat" -> false,


### PR DESCRIPTION
fix #10 

Repeat step order in json dump was hard coded, so the last repeat was always inserted as second step